### PR TITLE
Die operation description

### DIFF
--- a/src/diceRoller.ts
+++ b/src/diceRoller.ts
@@ -514,6 +514,7 @@ export class DiceRoller {
 			while (i < rolls.length && dropped < toDrop) {
 				if (rolls[i].valid) {
 					rolls[i].valid = false;
+					rolls[i].operation = 'drop'
 					dropped++;
 				}
 
@@ -539,6 +540,7 @@ export class DiceRoller {
 			while (i < rolls.length && dropped < toDrop) {
 				if (rolls[i].valid) {
 					rolls[i].valid = false;
+					rolls[i].operation = 'drop'
 					dropped++;
 				}
 
@@ -573,6 +575,7 @@ export class DiceRoller {
 				let explodeCount = 0;
 
 				while (targetMethod(roll) && explodeCount++ < 1000) {
+					roll.operation = 'explode'
 					const newRoll = this.reRoll(roll, ++i);
 					rolls.splice(i, 0, newRoll);
 					roll = newRoll;
@@ -607,6 +610,7 @@ export class DiceRoller {
 				let explodeCount = 0;
 
 				while (targetMethod(roll) && explodeCount++ < 1000) {
+					roll.operation = 'explode'
 					const newRoll = this.reRoll(roll,i+1);
 					rollValue += newRoll.roll;
 					roll = newRoll;
@@ -644,6 +648,7 @@ export class DiceRoller {
 				let explodeCount = 0;
 
 				while (targetMethod(roll) && explodeCount++ < 1000) {
+					roll.operation = 'explode'
 					const newRoll = this.reRoll(roll, ++i);
 					newRoll.value -= 1;
 					newRoll.roll -= 1;
@@ -668,6 +673,7 @@ export class DiceRoller {
 
 			for (let i = 0; i < rolls.length; i++) {
 				while (targetMethod(rolls[i].roll)) {
+					rolls[i].operation = 'reroll'
 					rolls[i].valid = false;
 					const newRoll = this.reRoll(rolls[i], i + 1);
 					rolls.splice(++i, 0, newRoll);
@@ -690,6 +696,7 @@ export class DiceRoller {
 
 			for (let i = 0; i < rolls.length; i++) {
 				if (targetMethod(rolls[i].roll)) {
+					rolls[i].operation = 'reroll'
 					rolls[i].valid = false;
 					const newRoll = this.reRoll(rolls[i], i + 1);
 					rolls.splice(++i, 0, newRoll);

--- a/src/rollTypes.ts
+++ b/src/rollTypes.ts
@@ -28,6 +28,8 @@ export interface RollBase {
 	label?: string;
 	/** A property used to maintain ordering of dice rolls within groups */
 	order: number;
+	/** Any special operations appied to this die */
+	operation?: string;
 }
 
 /** An intermediate interface extended for groups of dice */

--- a/test/rollerTest.test.ts
+++ b/test/rollerTest.test.ts
@@ -66,7 +66,8 @@ testRolls.forEach(([roll, expectedValue]) => {
 
 const testFixedRolls: [string, number, number[]][] = [
 	['1d6!!', 14, [.84, .84, .17]], // value = [6,6,2]
-	['4d6!!', 24, [.84, .67, .5, .17, .84, 0]] // value = [6,5,4,2,6,1]
+	['4d6!!', 24, [.84, .67, .5, .17, .84, 0]], // value = [6,5,4,2,6,1]
+	['4d6dl1', 15, [.84, .67, .5, .17]] // value = [6,5,4,2]
 ]
 
 let externalCount: number = 0


### PR DESCRIPTION
Adding an additional `operation` property descriptor to `RollBase` die objects. This will easily flag dice as 'drop', 'reroll' and 'explode'.

Use Case: After getting the final roll results, I'd like to mark which dice have been dropped, rerolled, or exploded. For example, when rolling `4d6dl1`. Using the `valid` property doesn't always explain why a die may have been invalidated. Also, a dice that is `critical: "success"` doesn't always explode. This new property will help to clear that up for post-processing.